### PR TITLE
feat: added new m2m gateway documents config

### DIFF
--- a/microservices/m2m-gateway/dev/values.yaml
+++ b/microservices/m2m-gateway/dev/values.yaml
@@ -23,6 +23,13 @@ configmap:
   DEFAULT_POLLING_MAX_RETRIES: "20"
   ESERVICE_DOCUMENTS_CONTAINER: "interop-application-documents-{{.Values.namespace}}-es1"
   ESERVICE_DOCUMENTS_PATH: "eservices/docs"
+  
+  RISK_ANALYSIS_DOCUMENTS_CONTAINER: "interop-application-documents-{{.Values.namespace}}-es1"
+  RISK_ANALYSIS_DOCUMENTS_PATH: "{{.Values.namespace}}/risk-analysis/docs"
+
+  AGREEMENT_CONSUMER_DOCUMENTS_CONTAINER: "interop-application-documents-{{.Values.namespace}}-es1"
+  AGREEMENT_CONSUMER_DOCUMENTS_PATH: "{{.Values.namespace}}/agreement/consumer-docs"
+  AGREEMENT_CONSUMER_CONTRACTS_PATH: "{{.Values.namespace}}/agreement/contracts"
 deployment:
   env:
     HOST: "0.0.0.0"


### PR DESCRIPTION
Added risk analysis documents download configs, taken from `bff`'s `values.yaml`:
- `RISK_ANALYSIS_DOCUMENTS_CONTAINER`
- `RISK_ANALYSIS_DOCUMENTS_PATH`

Added agreement consumer documents and contracts, taken from `agreement-process`'s `values.yaml`:
 - AGREEMENT_CONSUMER_DOCUMENTS_CONTAINER
 - AGREEMENT_CONSUMER_DOCUMENTS_PATH
 - AGREEMENT_CONSUMER_CONTRACTS_PATH