### PR TITLE
PIN-7089: Add EROR_DATA_DURATION_TIME on window env for frontend

### DIFF
--- a/microservices/frontend/att/values.yaml
+++ b/microservices/frontend/att/values.yaml
@@ -26,6 +26,7 @@ frontend:
       PRODUCER_ALLOWED_ORIGINS : "IPA,ANAC,IVASS,INFOCAMERE,SELC,SELC-PT,PDND_INFOCAMERE-SCP,PDND_INFOCAMERE-PRV,PDND_INFOCAMERE-PT,INFOCAMERE-PT"
       API_SIGNAL_HUB_PUSH_INTERFACE_URL : "https://raw.githubusercontent.com/pagopa/interop-signalhub-core/refs/heads/main/docs/openAPI/push-signals.yaml"
       API_SIGNAL_HUB_PULL_INTERFACE_URL : "https://raw.githubusercontent.com/pagopa/interop-signalhub-core/refs/heads/main/docs/openAPI/pull-signals.yaml"
+      ERROR_DATA_DURATION_TIME: "120000"
       fromConfigmaps:
         FEATURE_FLAG_ADMIN_CLIENT: "common-feature-flags.FEATURE_FLAG_ADMIN_CLIENT"
         FEATURE_FLAG_AGREEMENT_APPROVAL_POLICY_UPDATE: "common-feature-flags.FEATURE_FLAG_AGREEMENT_APPROVAL_POLICY_UPDATE"

--- a/microservices/frontend/dev/values.yaml
+++ b/microservices/frontend/dev/values.yaml
@@ -26,6 +26,7 @@ frontend:
       API_SIGNAL_HUB_PUSH_INTERFACE_URL : "https://raw.githubusercontent.com/pagopa/interop-signalhub-core/refs/heads/develop/docs/openAPI/push-signals.yaml"
       API_SIGNAL_HUB_PULL_INTERFACE_URL : "https://raw.githubusercontent.com/pagopa/interop-signalhub-core/refs/heads/develop/docs/openAPI/pull-signals.yaml"
       SIGNALHUB_PERSONAL_DATA_PROCESS_URL: "https://selfcare.dev.interop.pagopa.it/signalhub/pdnd_designazione_responsabilita_dati_personali_sh_v1.pdf"
+      ERROR_DATA_DURATION_TIME: "120000"
       fromConfigmaps:
         FEATURE_FLAG_ADMIN_CLIENT: "common-feature-flags.FEATURE_FLAG_ADMIN_CLIENT"
         FEATURE_FLAG_AGREEMENT_APPROVAL_POLICY_UPDATE: "common-feature-flags.FEATURE_FLAG_AGREEMENT_APPROVAL_POLICY_UPDATE"

--- a/microservices/frontend/prod/values.yaml
+++ b/microservices/frontend/prod/values.yaml
@@ -27,6 +27,7 @@ frontend:
       API_GATEWAY_V1_INTERFACE_URL: "https://selfcare.interop.pagopa.it/m2m/v1-interface-specification.yaml"
       API_GATEWAY_V2_INTERFACE_URL: "https://selfcare.interop.pagopa.it/m2m/v2-interface-specification.yaml"
       SIGNALHUB_PERSONAL_DATA_PROCESS_URL: "https://selfcare.interop.pagopa.it/signalhub/pdnd_designazione_responsabilita_dati_personali_sh_v1.pdf"
+      ERROR_DATA_DURATION_TIME: "120000"
       fromConfigmaps:
         FEATURE_FLAG_ADMIN_CLIENT: "common-feature-flags.FEATURE_FLAG_ADMIN_CLIENT"
         FEATURE_FLAG_AGREEMENT_APPROVAL_POLICY_UPDATE: "common-feature-flags.FEATURE_FLAG_AGREEMENT_APPROVAL_POLICY_UPDATE"

--- a/microservices/frontend/qa/values.yaml
+++ b/microservices/frontend/qa/values.yaml
@@ -26,6 +26,7 @@ frontend:
       API_SIGNAL_HUB_PUSH_INTERFACE_URL : "https://raw.githubusercontent.com/pagopa/interop-signalhub-core/refs/heads/develop/docs/openAPI/push-signals.yaml"
       API_SIGNAL_HUB_PULL_INTERFACE_URL : "https://raw.githubusercontent.com/pagopa/interop-signalhub-core/refs/heads/develop/docs/openAPI/pull-signals.yaml"
       SIGNALHUB_PERSONAL_DATA_PROCESS_URL: "https://selfcare.qa.interop.pagopa.it/signalhub/pdnd_designazione_responsabilita_dati_personali_sh_v1.pdf"
+      ERROR_DATA_DURATION_TIME: "120000"
       fromConfigmaps:
         FEATURE_FLAG_ADMIN_CLIENT: "common-feature-flags.FEATURE_FLAG_ADMIN_CLIENT"
         FEATURE_FLAG_AGREEMENT_APPROVAL_POLICY_UPDATE: "common-feature-flags.FEATURE_FLAG_AGREEMENT_APPROVAL_POLICY_UPDATE"

--- a/microservices/frontend/test/values.yaml
+++ b/microservices/frontend/test/values.yaml
@@ -27,6 +27,7 @@ frontend:
       API_GATEWAY_V1_INTERFACE_URL: "https://selfcare.uat.interop.pagopa.it/m2m/v1-interface-specification.yaml"
       API_GATEWAY_V2_INTERFACE_URL: "https://selfcare.uat.interop.pagopa.it/m2m/v2-interface-specification.yaml"
       SIGNALHUB_PERSONAL_DATA_PROCESS_URL: "https://selfcare.uat.interop.pagopa.it/signalhub/pdnd_designazione_responsabilita_dati_personali_sh_v1.pdf"
+      ERROR_DATA_DURATION_TIME: "120000"
       fromConfigmaps:
         FEATURE_FLAG_ADMIN_CLIENT: "common-feature-flags.FEATURE_FLAG_ADMIN_CLIENT"
         FEATURE_FLAG_AGREEMENT_APPROVAL_POLICY_UPDATE: "common-feature-flags.FEATURE_FLAG_AGREEMENT_APPROVAL_POLICY_UPDATE"

--- a/microservices/frontend/vapt/values.yaml
+++ b/microservices/frontend/vapt/values.yaml
@@ -25,6 +25,7 @@ frontend:
       PRODUCER_ALLOWED_ORIGINS : "IPA"
       API_SIGNAL_HUB_PUSH_INTERFACE_URL : "https://raw.githubusercontent.com/pagopa/interop-signalhub-core/refs/heads/develop/docs/openAPI/push-signals.yaml"
       API_SIGNAL_HUB_PULL_INTERFACE_URL : "https://raw.githubusercontent.com/pagopa/interop-signalhub-core/refs/heads/develop/docs/openAPI/pull-signals.yaml"
+      ERROR_DATA_DURATION_TIME: "120000"
       fromConfigmaps:
         FEATURE_FLAG_ADMIN_CLIENT: "common-feature-flags.FEATURE_FLAG_ADMIN_CLIENT"
         FEATURE_FLAG_AGREEMENT_APPROVAL_POLICY_UPDATE: "common-feature-flags.FEATURE_FLAG_AGREEMENT_APPROVAL_POLICY_UPDATE"


### PR DESCRIPTION
`EROR_DATA_DURATION_TIME` var describe on frontend how much time is between saving correlationId and errorCode to pass within assistance link and its expiration (after this time if user click on assistance link, ticket will not include that information) 

More info: https://pagopa.atlassian.net/browse/PIN-7089