### PR TITLE
PIN-7357: Grant delegation and template SCHEMA for datalake-data-export

### DIFF
--- a/commons/att/configmaps/flyway-readmodel-delegation-configmap.yaml
+++ b/commons/att/configmaps/flyway-readmodel-delegation-configmap.yaml
@@ -72,3 +72,7 @@ data:
     GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_delegation" TO "${NAMESPACE}_authorization_process_user";
     GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_delegation" TO "${NAMESPACE}_purpose_process_user";
     GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_delegation" TO "${NAMESPACE}_tenant_process_user";
+
+  V1.1__Grant_Access_Job_Datalake-Export_Schema_Delegation.sql: |-
+    GRANT USAGE ON SCHEMA "${NAMESPACE}_delegation" TO "${NAMESPACE}_datalake_data_export_user";    
+    GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_delegation" TO "${NAMESPACE}_datalake_data_export_user";

--- a/commons/att/configmaps/flyway-readmodel-eservice-template-configmap.yaml
+++ b/commons/att/configmaps/flyway-readmodel-eservice-template-configmap.yaml
@@ -143,3 +143,7 @@ data:
 
   V1.2__Add_Column_TenantId_RiskAnalysis_Template.sql: |-
     ALTER TABLE IF EXISTS "${NAMESPACE}_eservice_template".eservice_template_risk_analysis ADD COLUMN IF NOT EXISTS tenant_kind VARCHAR NOT NULL;
+
+  V1.3_Grant_Access_Job_Datalake-Export_Schema_Template.sql: |-
+    GRANT USAGE ON SCHEMA "${NAMESPACE}_eservice_template" TO "${NAMESPACE}_datalake_data_export_user";    
+    GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_eservice_template" TO "${NAMESPACE}_datalake_data_export_user";

--- a/commons/dev/configmaps/flyway-readmodel-delegation-configmap.yaml
+++ b/commons/dev/configmaps/flyway-readmodel-delegation-configmap.yaml
@@ -74,3 +74,7 @@ data:
     GRANT USAGE ON SCHEMA "${NAMESPACE}_delegation" to "${NAMESPACE}_authorization_process_user";    
     GRANT USAGE ON SCHEMA "${NAMESPACE}_delegation" to "${NAMESPACE}_purpose_process_user";    
     GRANT USAGE ON SCHEMA "${NAMESPACE}_delegation" to "${NAMESPACE}_tenant_process_user";    
+
+  V1.3__Grant_Access_Job_Datalake-Export_Schema_Delegation.sql: |-
+    GRANT USAGE ON SCHEMA "${NAMESPACE}_delegation" TO "${NAMESPACE}_datalake_data_export_user";    
+    GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_delegation" TO "${NAMESPACE}_datalake_data_export_user";

--- a/commons/dev/configmaps/flyway-readmodel-eservice-template-configmap.yaml
+++ b/commons/dev/configmaps/flyway-readmodel-eservice-template-configmap.yaml
@@ -145,3 +145,7 @@ data:
 
   V1.4__Add_Column_TenantId_RiskAnalysis_Template.sql: |-
     ALTER TABLE IF EXISTS "${NAMESPACE}_eservice_template".eservice_template_risk_analysis ADD COLUMN IF NOT EXISTS tenant_kind VARCHAR NOT NULL;
+  
+  V1.5_Grant_Access_Job_Datalake-Export_Schema_Template.sql: |-
+    GRANT USAGE ON SCHEMA "${NAMESPACE}_eservice_template" TO "${NAMESPACE}_datalake_data_export_user";    
+    GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_eservice_template" TO "${NAMESPACE}_datalake_data_export_user";

--- a/commons/qa/configmaps/flyway-readmodel-delegation-configmap.yaml
+++ b/commons/qa/configmaps/flyway-readmodel-delegation-configmap.yaml
@@ -72,3 +72,7 @@ data:
     GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_delegation" TO "${NAMESPACE}_authorization_process_user";
     GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_delegation" TO "${NAMESPACE}_purpose_process_user";
     GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_delegation" TO "${NAMESPACE}_tenant_process_user";
+
+  V1.1__Grant_Access_Job_Datalake-Export_Schema_Delegation.sql: |-
+    GRANT USAGE ON SCHEMA "${NAMESPACE}_delegation" TO "${NAMESPACE}_datalake_data_export_user";    
+    GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_delegation" TO "${NAMESPACE}_datalake_data_export_user";

--- a/commons/qa/configmaps/flyway-readmodel-eservice-template-configmap.yaml
+++ b/commons/qa/configmaps/flyway-readmodel-eservice-template-configmap.yaml
@@ -143,3 +143,7 @@ data:
 
   V1.2__Add_Column_TenantId_RiskAnalysis_Template.sql: |-
     ALTER TABLE IF EXISTS "${NAMESPACE}_eservice_template".eservice_template_risk_analysis ADD COLUMN IF NOT EXISTS tenant_kind VARCHAR NOT NULL;
+
+  V1.3_Grant_Access_Job_Datalake-Export_Schema_Template.sql: |-
+    GRANT USAGE ON SCHEMA "${NAMESPACE}_eservice_template" TO "${NAMESPACE}_datalake_data_export_user";    
+    GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_eservice_template" TO "${NAMESPACE}_datalake_data_export_user";

--- a/commons/test/configmaps/flyway-readmodel-delegation-configmap.yaml
+++ b/commons/test/configmaps/flyway-readmodel-delegation-configmap.yaml
@@ -72,3 +72,7 @@ data:
     GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_delegation" TO "${NAMESPACE}_authorization_process_user";
     GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_delegation" TO "${NAMESPACE}_purpose_process_user";
     GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_delegation" TO "${NAMESPACE}_tenant_process_user";
+
+  V1.1__Grant_Access_Job_Datalake-Export_Schema_Delegation.sql: |-
+    GRANT USAGE ON SCHEMA "${NAMESPACE}_delegation" TO "${NAMESPACE}_datalake_data_export_user";    
+    GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_delegation" TO "${NAMESPACE}_datalake_data_export_user";

--- a/commons/test/configmaps/flyway-readmodel-eservice-template-configmap.yaml
+++ b/commons/test/configmaps/flyway-readmodel-eservice-template-configmap.yaml
@@ -143,3 +143,7 @@ data:
 
   V1.2__Add_Column_TenantId_RiskAnalysis_Template.sql: |-
     ALTER TABLE IF EXISTS "${NAMESPACE}_eservice_template".eservice_template_risk_analysis ADD COLUMN IF NOT EXISTS tenant_kind VARCHAR NOT NULL;
+
+  V1.3_Grant_Access_Job_Datalake-Export_Schema_Template.sql: |-
+    GRANT USAGE ON SCHEMA "${NAMESPACE}_eservice_template" TO "${NAMESPACE}_datalake_data_export_user";    
+    GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_eservice_template" TO "${NAMESPACE}_datalake_data_export_user";


### PR DESCRIPTION
This PR add GRANT in order to allow service `datalake-data-export` to access on eservice-template's and delegation's SCHEMA. **This is valid for all enviroments excepts for PROD (we're going to add this when we will ready to go live)**