### PR TITLE
feat: add NODE_ENV var in QA

### DIFF
--- a/commons/qa/values-cronjob.yaml
+++ b/commons/qa/values-cronjob.yaml
@@ -8,6 +8,7 @@ cronjob:
     digest: $IMAGE_DIGEST_PLACEHOLDER
   env:
     LOG_LEVEL: "info"
+    NODE_ENV: "production"
   resources:
     requests:
       cpu: "1000m"

--- a/commons/qa/values-microservice.yaml
+++ b/commons/qa/values-microservice.yaml
@@ -14,6 +14,7 @@ deployment:
     digest: $IMAGE_DIGEST_PLACEHOLDER
   env:
     LOG_LEVEL: "info"
+    NODE_ENV: "production"
   resources:
     requests:
       cpu: "1000m"


### PR DESCRIPTION
As per nodejs practices, the `NODE_ENV` variable should be ignored, but some libraries (like express) use it to apply different behaviours.

This PR sets the variable to `production` in order to avoid dev environment behaviours