### PR TITLE
Notification migrations for entity id and preferences

### DIFF
--- a/commons/dev/configmaps/flyway-in-app-notification-db-migrations-configmap.yaml
+++ b/commons/dev/configmaps/flyway-in-app-notification-db-migrations-configmap.yaml
@@ -29,3 +29,7 @@ data:
     GRANT SELECT, UPDATE, DELETE ON ALL TABLES IN SCHEMA "${NAMESPACE}_notification" TO "${NAMESPACE}_in_app_notification_manager_user";
     GRANT SELECT, INSERT ON ALL TABLES IN SCHEMA "${NAMESPACE}_notification" TO "${NAMESPACE}_in_app_notification_dispatcher_user";
     GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_notification" TO "readonly_user";
+ 
+  V1.1__EntityId_Varchar.sql: |-
+    ALTER TABLE "${NAMESPACE}_notification".notification
+      ALTER COLUMN entity_id TYPE VARCHAR USING entity_id::TEXT;

--- a/commons/dev/configmaps/flyway-readmodel-notification-config-configmap.yaml
+++ b/commons/dev/configmaps/flyway-readmodel-notification-config-configmap.yaml
@@ -55,3 +55,15 @@ data:
     GRANT SELECT, UPDATE, INSERT, DELETE ON ALL TABLES IN SCHEMA "${NAMESPACE}_notification_config" TO "${NAMESPACE}_notification_config_rmw_user";
     GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_notification_config" TO "${NAMESPACE}_notification_config_process_user";
     GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_notification_config" TO "readonly_user";
+
+  V1.2__AddPreferences_NotificationConfig.sql: |-
+    ALTER TABLE "${NAMESPACE}_notification_config".tenant_notification_config
+      ADD COLUMN IF NOT EXISTS in_app_notification_preference BOOLEAN,
+      ADD COLUMN IF NOT EXISTS email_notification_preference VARCHAR;
+    UPDATE "${NAMESPACE}_notification_config".tenant_notification_config
+      SET in_app_notification_preference = FALSE WHERE in_app_notification_preference IS NULL;
+    UPDATE "${NAMESPACE}_notification_config".tenant_notification_config
+      SET email_notification_preference = 'Disabled' WHERE email_notification_preference IS NULL;
+    ALTER TABLE "${NAMESPACE}_notification_config".tenant_notification_config
+      ALTER COLUMN in_app_notification_preference SET NOT NULL,
+      ALTER COLUMN email_notification_preference SET NOT NULL;


### PR DESCRIPTION
Extract from #297 the changes unrelated to dispatchers/consumers/users (which we are not merging for now)