### PR TITLE
chore: change migration's version to align with env PROD, on purpose configmap

### DIFF
--- a/commons/qa/configmaps/flyway-readmodel-purpose-configmap.yaml
+++ b/commons/qa/configmaps/flyway-readmodel-purpose-configmap.yaml
@@ -135,6 +135,11 @@ data:
     GRANT SELECT, UPDATE, INSERT, DELETE ON TABLE "${NAMESPACE}_purpose".purpose_version_stamp TO "${NAMESPACE}_purpose_rmw_user";
     GRANT SELECT ON TABLE "${NAMESPACE}_purpose".purpose_version_stamp TO "${NAMESPACE}_purpose_process_user";
     GRANT SELECT ON TABLE "${NAMESPACE}_purpose".purpose_version_stamp TO readonly_user;
+    GRANT SELECT ON TABLE "${NAMESPACE}_purpose".purpose_version_stamp TO "${NAMESPACE}_authorization_process_user";
+    GRANT SELECT ON TABLE "${NAMESPACE}_purpose".purpose_version_stamp TO "${NAMESPACE}_datalake_data_export_user";
+    GRANT SELECT ON TABLE "${NAMESPACE}_purpose".purpose_version_stamp TO "${NAMESPACE}_delegation_items_archiver_user";
+    GRANT SELECT ON TABLE "${NAMESPACE}_purpose".purpose_version_stamp TO "${NAMESPACE}_pn_consumers_user";
+    GRANT SELECT ON TABLE "${NAMESPACE}_purpose".purpose_version_stamp TO "${NAMESPACE}_token_generation_readmodel_checker_user";
 
   V1.5__Add_Archiviazione_Documentale_signed_document_table.sql: |-
     CREATE TABLE IF NOT EXISTS "${NAMESPACE}_purpose".purpose_version_signed_document (

--- a/commons/qa/configmaps/flyway-readmodel-purpose-configmap.yaml
+++ b/commons/qa/configmaps/flyway-readmodel-purpose-configmap.yaml
@@ -136,18 +136,7 @@ data:
     GRANT SELECT ON TABLE "${NAMESPACE}_purpose".purpose_version_stamp TO "${NAMESPACE}_purpose_process_user";
     GRANT SELECT ON TABLE "${NAMESPACE}_purpose".purpose_version_stamp TO readonly_user;
 
-  V1.5__Allow_AuthorizationProcess_To_Read_PurposeVersionStamp.sql: |-
-    GRANT SELECT ON TABLE "${NAMESPACE}_purpose".purpose_version_stamp TO "${NAMESPACE}_authorization_process_user";
-
-  V1.6__Allow_Jobs_To_Read_PurposeVersionStamp.sql: |-
-    GRANT SELECT ON TABLE "${NAMESPACE}_purpose".purpose_version_stamp TO "${NAMESPACE}_datalake_data_export_user";
-    GRANT SELECT ON TABLE "${NAMESPACE}_purpose".purpose_version_stamp TO "${NAMESPACE}_pn_consumers_user";
-    GRANT SELECT ON TABLE "${NAMESPACE}_purpose".purpose_version_stamp TO "${NAMESPACE}_token_generation_readmodel_checker_user";
-
-  V1.7__Allow_DelegationItemsArchiver_To_Read_PurposeVersionStamp.sql: |-
-    GRANT SELECT ON TABLE "${NAMESPACE}_purpose".purpose_version_stamp TO "${NAMESPACE}_delegation_items_archiver_user";
-
-  V1.8__Add_Archiviazione_Documentale_signed_document_table.sql: |-
+  V1.5__Add_Archiviazione_Documentale_signed_document_table.sql: |-
     CREATE TABLE IF NOT EXISTS "${NAMESPACE}_purpose".purpose_version_signed_document (
       purpose_id UUID NOT NULL REFERENCES "${NAMESPACE}_purpose".purpose (id) ON DELETE CASCADE,
       metadata_version INTEGER NOT NULL,

--- a/commons/test/configmaps/flyway-readmodel-purpose-configmap.yaml
+++ b/commons/test/configmaps/flyway-readmodel-purpose-configmap.yaml
@@ -141,18 +141,7 @@ data:
     GRANT SELECT ON TABLE "${NAMESPACE}_purpose".purpose_version_stamp TO "${NAMESPACE}_pn_consumers_user";
     GRANT SELECT ON TABLE "${NAMESPACE}_purpose".purpose_version_stamp TO "${NAMESPACE}_token_generation_readmodel_checker_user";
 
-  V1.5__Allow_AuthorizationProcess_To_Read_PurposeVersionStamp.sql: |-
-    GRANT SELECT ON TABLE "${NAMESPACE}_purpose".purpose_version_stamp TO "${NAMESPACE}_authorization_process_user";
-
-  V1.6__Allow_Jobs_To_Read_PurposeVersionStamp.sql: |-
-    GRANT SELECT ON TABLE "${NAMESPACE}_purpose".purpose_version_stamp TO "${NAMESPACE}_datalake_data_export_user";
-    GRANT SELECT ON TABLE "${NAMESPACE}_purpose".purpose_version_stamp TO "${NAMESPACE}_pn_consumers_user";
-    GRANT SELECT ON TABLE "${NAMESPACE}_purpose".purpose_version_stamp TO "${NAMESPACE}_token_generation_readmodel_checker_user";
-
-  V1.7__Allow_DelegationItemsArchiver_To_Read_PurposeVersionStamp.sql: |-
-    GRANT SELECT ON TABLE "${NAMESPACE}_purpose".purpose_version_stamp TO "${NAMESPACE}_delegation_items_archiver_user";
-
-  V1.8__Add_Archiviazione_Documentale_signed_document_table.sql: |-
+  V1.5__Add_Archiviazione_Documentale_signed_document_table.sql: |-
     CREATE TABLE IF NOT EXISTS "${NAMESPACE}_purpose".purpose_version_signed_document (
       purpose_id UUID NOT NULL REFERENCES "${NAMESPACE}_purpose".purpose (id) ON DELETE CASCADE,
       metadata_version INTEGER NOT NULL,


### PR DESCRIPTION
# WARNING
⚠️ ⚠️ ⚠️ 

To merge only after these migrations
- 1.4
- 1.5
- 1.6
- 1.7
- 1.8
have been deleted from tables:
- `qa_purpose.flyway_schema_history`
- `test_purpose.flyway_schema_history`