### PR TITLE
fix: grant purpose-template-process access to eservice-template schema (PIN-8621)

### DIFF
--- a/commons/dev/configmaps/flyway-readmodel-eservice-template-configmap.yaml
+++ b/commons/dev/configmaps/flyway-readmodel-eservice-template-configmap.yaml
@@ -156,3 +156,7 @@ data:
   V1.7__Grant_Access_PurposeTemplateProcess_Template.sql: |-
     GRANT USAGE ON SCHEMA "${NAMESPACE}_eservice_template" TO "${NAMESPACE}_email_digest_dispatcher_user";    
     GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_eservice_template" TO "${NAMESPACE}_email_digest_dispatcher_user";
+
+  V1.8__Grant_Access_PurposeTemplateProcess_EserviceTemplate.sql: |-
+    GRANT USAGE ON SCHEMA "${NAMESPACE}_eservice_template" TO "${NAMESPACE}_purpose_template_process_user";
+    GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_eservice_template" TO "${NAMESPACE}_purpose_template_process_user";


### PR DESCRIPTION
## Summary

Add `V1.8__Grant_Access_PurposeTemplateProcess_EserviceTemplate.sql` to grant `purpose_template_process_user` USAGE on schema `eservice_template` and SELECT on all its tables.

Required by the new `GET /purposeTemplates/{id}/eserviceTemplates` endpoint, which joins `eservice_template_version_purpose_template` with `eservice_template` across schemas; without this grant it fails with `permission denied` (500).