### PR TITLE
fix(dev): grant SELECT on async-exchange properties to purpose-template-process and other readers

### DIFF
--- a/commons/dev/configmaps/flyway-readmodel-eservice-template-configmap.yaml
+++ b/commons/dev/configmaps/flyway-readmodel-eservice-template-configmap.yaml
@@ -200,3 +200,9 @@ data:
   V1.13__Grant_Access_Async_Exchange_Properties_EServiceTemplate.sql: |-
     GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_eservice_template" TO "${NAMESPACE}_catalog_process_user";
 
+  V1.14__Grant_Access_Async_Exchange_Properties_EServiceTemplate_Additional_Users.sql: |-
+    GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_eservice_template" TO
+      "${NAMESPACE}_purpose_template_process_user",
+      "${NAMESPACE}_eservice_template_instances_updater_user",
+      "${NAMESPACE}_datalake_data_export_user",
+      "${NAMESPACE}_email_digest_dispatcher_user";


### PR DESCRIPTION
Follow-up to #683.

#683 granted SELECT on the new `eservice_template_version_async_exchange_properties` table only to `${NAMESPACE}_catalog_process_user`.

Other users that historically had `GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_eservice_template"` (V1.3, V1.5, V1.7, V1.8) were left without SELECT on the new table, because `GRANT … ON ALL TABLES IN SCHEMA` applies only to tables existing at grant time and there are no `ALTER DEFAULT PRIVILEGES` configured.

Observable effect on dev: `POST /purposeTemplates/{id}/linkResource` with `resourceKind=ESERVICE_TEMPLATE` returns 400 with code `015-0029` (`associationEServiceTemplatesForPurposeTemplateFailed`) and `detail` containing the SQL of `getEServiceTemplateById` (LEFT JOIN on the async-exchange properties table). Root cause is `permission denied` on the new table for `${NAMESPACE}_purpose_template_process_user`.

V1.14 grants SELECT on the schema's tables to:
- `purpose_template_process_user` — fixes the visible 015-0029
- `eservice_template_instances_updater_user`
- `datalake_data_export_user`
- `email_digest_dispatcher_user`

`async_token_generation_readmodel_checker_user` is already covered (V1.12 runs after V1.11).

Scope: dev only — `test/qa/att/vapt/prod` do not yet have the V1.11 migration; the same fix will need to ship alongside the rollout to those envs.