### PR TITLE
fix(dev): grant SELECT on producer_keychain to notification dispatcher users

### DIFF
--- a/commons/dev/configmaps/flyway-readmodel-producer-keychain-configmap.yaml
+++ b/commons/dev/configmaps/flyway-readmodel-producer-keychain-configmap.yaml
@@ -68,3 +68,11 @@ data:
   V1.1__Grant_Access_AsyncTokenGenerationRMChecker_ProducerKeychain.sql: |-
     GRANT USAGE ON SCHEMA "${NAMESPACE}_producer_keychain" to "${NAMESPACE}_async_token_generation_readmodel_checker_user";
     GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_producer_keychain" TO "${NAMESPACE}_async_token_generation_readmodel_checker_user";
+
+  V1.2__Grant_Access_NotificationDispatchers_ProducerKeychain.sql: |-
+    GRANT USAGE ON SCHEMA "${NAMESPACE}_producer_keychain" TO
+      "${NAMESPACE}_email_notification_dispatcher_user",
+      "${NAMESPACE}_in_app_notification_dispatcher_user";
+    GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_producer_keychain" TO
+      "${NAMESPACE}_email_notification_dispatcher_user",
+      "${NAMESPACE}_in_app_notification_dispatcher_user";


### PR DESCRIPTION
## Summary

- Add `V1.2__Grant_Access_NotificationDispatchers_ProducerKeychain.sql` to `commons/dev/configmaps/flyway-readmodel-producer-keychain-configmap.yaml`.
- Grants `USAGE` on schema `${NAMESPACE}_producer_keychain` and `SELECT` on all tables to `${NAMESPACE}_email_notification_dispatcher_user` and `${NAMESPACE}_in_app_notification_dispatcher_user`.

## Context

`email-notification-dispatcher` and `in-app-notification-dispatcher` build a `producerKeychainReadModelServiceSQL` (see `packages/{email,in-app}-notification-dispatcher/src/index.ts` and `services/readModelServiceSQL.ts` in `interop-be-monorepo`) and query `producer_keychain` joined with `producer_keychain_eservice`, but the migrations granted neither USAGE on the schema nor SELECT on the tables to the dispatcher users. This caused the runtime failures reported on `dev`:

```
Failed query: select "dev_producer_keychain"."producer_keychain"."id"
from "dev_producer_keychain"."producer_keychain_eservice"
inner join "dev_producer_keychain"."producer_keychain" on ...
```

The other read-model schemas consumed by the dispatchers (`agreement`, `attribute`, `catalog`, `delegation`, `notification_config`, `purpose`, `tenant`) already include analogous grants — this aligns `producer_keychain` with that pattern.

The matching migration for QA is on `PIN-10162-qa-async-exchange-rollout-and-feature-flag-cleanups` (PR #688).