### PR TITLE
fix(dev): readmodel grants for scheduled notification dispatchers and new tenant tables

### DIFF
--- a/commons/dev/configmaps/flyway-readmodel-agreement-configmap.yaml
+++ b/commons/dev/configmaps/flyway-readmodel-agreement-configmap.yaml
@@ -192,3 +192,11 @@ data:
     GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_agreement" TO
       "${NAMESPACE}_email_notification_dispatcher_user",
       "${NAMESPACE}_in_app_notification_dispatcher_user";
+
+  V1.16__Fix_Grant_Access_ScheduledNotificationDispatchers_Agreement.sql: |-
+    GRANT USAGE ON SCHEMA "${NAMESPACE}_agreement" TO
+      "${NAMESPACE}_email_scheduled_notification_dispatcher_user",
+      "${NAMESPACE}_in_app_scheduled_notification_dispatcher_user";
+    GRANT SELECT ON ALL TABLES IN SCHEMA "${NAMESPACE}_agreement" TO
+      "${NAMESPACE}_email_scheduled_notification_dispatcher_user",
+      "${NAMESPACE}_in_app_scheduled_notification_dispatcher_user";

--- a/commons/dev/configmaps/flyway-readmodel-tenant-configmap.yaml
+++ b/commons/dev/configmaps/flyway-readmodel-tenant-configmap.yaml
@@ -293,3 +293,32 @@ data:
   
   V1.8.2__ipa_Job_username_GRANTS_new_table_Tenant.sql: |-
     GRANT SELECT ON TABLE "${NAMESPACE}_tenant".tenant_certified_discrete_attribute TO "${NAMESPACE}_ipa_certified_attributes_importer_user";
+
+  V1.8.3__Grant_Select_NewTables_SchemaReadUsers_Tenant.sql: |-
+    GRANT SELECT ON TABLE "${NAMESPACE}_tenant".tenant_certified_discrete_attribute, "${NAMESPACE}_tenant".tenant_remote_id TO
+      "${NAMESPACE}_agreement_process_user",
+      "${NAMESPACE}_catalog_process_user",
+      "${NAMESPACE}_attribute_registry_process_user",
+      "${NAMESPACE}_delegation_process_user",
+      "${NAMESPACE}_eservice_template_process_user",
+      "${NAMESPACE}_purpose_process_user",
+      "${NAMESPACE}_anac_certified_attributes_importer_user",
+      "${NAMESPACE}_certified_email_sender_user",
+      "${NAMESPACE}_datalake_data_export_user",
+      "${NAMESPACE}_dtd_catalog_exporter_user",
+      "${NAMESPACE}_ivass_certified_attributes_importer_user",
+      "${NAMESPACE}_notification_email_sender_user",
+      "${NAMESPACE}_pn_consumers_user",
+      "${NAMESPACE}_selfcare_client_users_updater_user",
+      "${NAMESPACE}_notification_config_process_user",
+      "${NAMESPACE}_purpose_template_process_user",
+      "${NAMESPACE}_documents_generator_user",
+      "${NAMESPACE}_email_notification_dispatcher_user",
+      "${NAMESPACE}_in_app_notification_dispatcher_user",
+      "${NAMESPACE}_email_sender_user",
+      "${NAMESPACE}_notification_user_lifecycle_consumer_user",
+      "${NAMESPACE}_authorization_process_user",
+      "${NAMESPACE}_email_digest_dispatcher_user",
+      "${NAMESPACE}_private_certified_attributes_importer_user",
+      "${NAMESPACE}_email_scheduled_notification_dispatcher_user",
+      "${NAMESPACE}_in_app_scheduled_notification_dispatcher_user";


### PR DESCRIPTION
## Problem

In the dev environment, the `email-scheduled-notification-dispatcher` and `in-app-scheduled-notification-dispatcher` cronjobs fail to deliver every scheduled notification, and the `email-notification-dispatcher` / `in-app-notification-dispatcher` deployments are in CrashLoopBackOff. Two distinct readmodel permission gaps cause this:

1. **Agreement schema**: `V1.15__Grant_Access_ScheduledNotificationDispatchers_Agreement.sql` granted the **non-scheduled** dispatcher users (already covered by V1.12) instead of the scheduled ones — a copy-paste slip. The scheduled dispatchers fail with:
   `permission denied for schema dev_agreement`

2. **Tenant schema**: `V1.8__AddTables_AttributiCertificatiDiscreti_Tenant.sql` created `tenant_remote_id` and `tenant_certified_discrete_attribute` granting only rmw/process/readonly (plus istat/ipa importers). Every user that previously received `SELECT ON ALL TABLES` on the tenant schema (process users, dispatchers, senders, exporters, …) was left without SELECT on the new tables. Both dispatcher families fail with:
   `permission denied for table tenant_certified_discrete_attribute`

   This also breaks the readmodel tenant aggregate read for any other service running code that selects from the new tables.

## Fix

- `V1.16__Fix_Grant_Access_ScheduledNotificationDispatchers_Agreement.sql`: grant USAGE + SELECT ON ALL TABLES on the agreement schema to the scheduled dispatcher users.
- `V1.8.3__Grant_Select_NewTables_SchemaReadUsers_Tenant.sql`: grant SELECT on `tenant_certified_discrete_attribute` and `tenant_remote_id` to all users that previously had schema-wide SELECT on the tenant schema.

All 26 grantee roles were verified to exist in the dev database (`pg_roles`), so the migrations cannot fail on a missing role.