### PR TITLE
chore(dev,vapt): disable notification-tenant-lifecycle-consumer

### DIFF
--- a/microservices/notification-tenant-lifecycle-consumer/dev/values.yaml
+++ b/microservices/notification-tenant-lifecycle-consumer/dev/values.yaml
@@ -17,6 +17,7 @@ configmap:
   INTERNAL_JWT_SECONDS_DURATION: "1800"
 
 deployment:
+  replicas: 0
   envFromConfigmaps:
     KAFKA_BROKERS: "common-kafka.KAFKA_BROKERS"
     TENANT_TOPIC: "common-kafka.TENANT_TOPIC"

--- a/microservices/notification-tenant-lifecycle-consumer/vapt/values.yaml
+++ b/microservices/notification-tenant-lifecycle-consumer/vapt/values.yaml
@@ -17,6 +17,7 @@ configmap:
   INTERNAL_JWT_SECONDS_DURATION: "1800"
 
 deployment:
+  replicas: 0
   envFromConfigmaps:
     KAFKA_BROKERS: "common-kafka.KAFKA_BROKERS"
     TENANT_TOPIC: "common-kafka.TENANT_TOPIC"


### PR DESCRIPTION
To avoid duplication caused by data preparation, the notification-tenant-lifecycle-consumer should be disabled.