### PR TITLE
fix(PIN-10581,_m2m_jwt_auditing): fix TOKEN_AUDITING_TOPIC reference

### DIFF
--- a/microservices/token-details-persister-node/dev/values.yaml
+++ b/microservices/token-details-persister-node/dev/values.yaml
@@ -23,5 +23,5 @@ deployment:
   envFromFieldRef:
     AWS_ROLE_SESSION_NAME: "metadata.name"
   envFromConfigmaps:
-    TOKEN_AUDITING_TOPIC: "common-kafka.TOKEN_AUDITING_TOPIC"
+    TOKEN_AUDITING_TOPIC: "common-kafka.CONSUMER_TOKEN_AUDITING_TOPIC"
     KAFKA_BROKERS: "common-kafka.KAFKA_BROKERS"


### PR DESCRIPTION
This PR fixes the Helm values wiring for `token-details-persister-node` in the **dev** environment by updating the `TOKEN_AUDITING_TOPIC` configmap key reference to the correct Kafka topic entry defined in `common-kafka`.

**Changes:**
- Update `TOKEN_AUDITING_TOPIC` to reference `common-kafka.CONSUMER_TOKEN_AUDITING_TOPIC` in `microservices/token-details-persister-node/dev/values.yaml`.
