### PR TITLE
feature (DEV): migration grace period days

### DIFF
--- a/commons/dev/configmaps/flyway-readmodel-catalog-configmap.yaml
+++ b/commons/dev/configmaps/flyway-readmodel-catalog-configmap.yaml
@@ -371,3 +371,8 @@ data:
   V1.30__Add_Columns_ServerUrlsDescriptions_Catalog.sql: |-
     ALTER TABLE "${NAMESPACE}_catalog".eservice_descriptor  ADD COLUMN IF NOT EXISTS server_urls_descriptions VARCHAR ARRAY NOT NULL DEFAULT '{}';
     ALTER TABLE "${NAMESPACE}_catalog".eservice_descriptor ALTER COLUMN server_urls_descriptions DROP DEFAULT;
+
+  V1.31__Add_Grace_Period_Column_Catalog.sql: |-
+    ALTER TABLE "${NAMESPACE}_catalog".eservice_descriptor_archiving_schedule ADD grace_period_days integer NULL;
+    UPDATE "${NAMESPACE}_catalog".eservice_descriptor_archiving_schedule set grace_period_days=90 where grace_period_days is null;
+    ALTER TABLE "${NAMESPACE}_catalog".eservice_descriptor_archiving_schedule ALTER COLUMN grace_period_days SET NOT NULL;


### PR DESCRIPTION
## Add `grace_period_days` to catalog readmodel

**Context**: Grace period is moving from a hardcoded default (90 days) to user-configurable, making this column the new source of truth.

**Database Migration**:
(V1.30)
- Adds grace_period_days column to `eservice_descriptor_archiving_schedule`.
- Backfills ~10 legacy records with 90.
- Sets the column to NOT NULL.

**Event Reprocessing Strategy**: Legacy events do not contain this field. In Proto3, missing enum fields resolve to index 0 upon deserialization. By mapping enum index 0 to 90, reprocessed events will automatically write 90 to the DB without requiring hardcoded fallbacks in application logic.

Note: Relying on Proto3's default enum index is a pragmatic compromise for legacy data. We can investigate making this fallback logic more explicit in a future refactor if needed.